### PR TITLE
Optionally reduce the number of detections that are processed before filtering

### DIFF
--- a/sexysolver/parameters.h
+++ b/sexysolver/parameters.h
@@ -239,6 +239,7 @@ public:
     double maxSize = 0;                 // The maximum size of stars to include in the final list in pixels based on semi-major and semi-minor axes
     double minSize = 0;                 // The minimum size of stars to include in the final list in pixels based on semi-major and semi-minor axes
     double maxEllipse = 0;              // The maximum ratio between the semi-major and semi-minor axes for stars to include (a/b)
+    int initialKeep = 1000000;          // Number of stars to process before filtering.
     double keepNum = 0;                 // The number of brightest stars to keep in the list
     double removeBrightest = 0;         // The percentage of brightest stars to remove from the list
     double removeDimmest = 0;           // The percentage of dimmest stars to remove from the list


### PR DESCRIPTION
Rob, Here is a speedup I added to KStars.
FWIW, it shouldn't have any effect on your code unless you set params.initialKeep.
Feel free to rename.
The idea is that after sep_extract, it sorts the detections by the oval size, and only performs the "expensive processing", e.g. sep_flux_radius, on the top params.initialKeep detections when sorted by that oval size.

I defaulted it to a large number, so it doesn't have impact, but for my work will set it to, eg. a few hundred or less. So I get that many detections, then get their real HFRs etc, and return the desired number of those.