### PR TITLE
Fix file descriptor leak on index files

### DIFF
--- a/stellarsolver/astrometry/qfits-an/qfits_rw.c
+++ b/stellarsolver/astrometry/qfits-an/qfits_rw.c
@@ -229,6 +229,9 @@ int qfits_is_fits(const char * filename)
     magic = qfits_calloc(FITS_MAGIC_SZ+1, sizeof(char));
     if (fread(magic, 1, FITS_MAGIC_SZ, fp) != FITS_MAGIC_SZ) {
 		qfits_error("failed to read file [%s]: %s", filename, strerror(errno));
+        // Tidy up to avoid leaking file descriptors
+        fclose(fp);
+        qfits_free(magic);
 		return -1;
 	}
     fclose(fp);


### PR DESCRIPTION
Hi Rob,

I found a problem with file descriptors leaking in qfits_is_fits(). In my case each solve was leaking 30 file descriptors because 15 of my 270 index files were of size 0 (don't know why this happened). This triggered the leak issue.

**Problem:** 
File descriptors were leaking when `fread()` failed in `qfits_is_fits()`, causing accumulating open files on each solve attempt.

**Solution:**
- Added `fclose(fp)` before early return in error path
- Added `qfits_free(magic)` to prevent memory leak
- Tested with ~270 index files, leak eliminated