### PR TITLE
Add WCSData accessors for CRVAL, CRPIX, and CD

### DIFF
--- a/stellarsolver/wcsdata.cpp
+++ b/stellarsolver/wcsdata.cpp
@@ -126,3 +126,27 @@ bool WCSData::appendStarsRAandDEC(QList<FITSImage::Star> &stars)
     }
 }
 
+double WCSData::getCRVAL(int i) const 
+{
+    if(internalWCS)
+        return wcs.wcstan.crval[i];
+    else
+        return m_wcs->crval[i];
+}
+
+double WCSData::getCRPIX(int i) const 
+{ 
+    if(internalWCS)
+        return wcs.wcstan.crpix[i]; 
+    else
+        return m_wcs->crpix[i];
+}
+
+double WCSData::getCD(int i, int j) const 
+{ 
+    if(internalWCS)
+        return wcs.wcstan.cd[i][j]; 
+    else
+        return m_wcs->cd[i*2 + j];
+}
+

--- a/stellarsolver/wcsdata.h
+++ b/stellarsolver/wcsdata.h
@@ -46,9 +46,9 @@ public:
      */
     bool appendStarsRAandDEC(QList<FITSImage::Star> &stars);
 
-    double getCRVAL(int i) const { return wcs.wcstan.crval[i]; }
-    double getCRPIX(int i) const { return wcs.wcstan.crpix[i]; }
-    double getCD(int i, int j) const { return wcs.wcstan.cd[i][j]; }
+    double getCRVAL(int i) const;
+    double getCRPIX(int i) const;
+    double getCD(int i, int j) const;
 
 private:
 

--- a/stellarsolver/wcsdata.h
+++ b/stellarsolver/wcsdata.h
@@ -46,6 +46,10 @@ public:
      */
     bool appendStarsRAandDEC(QList<FITSImage::Star> &stars);
 
+    double getCRVAL(int i) const { return wcs.wcstan.crval[i]; }
+    double getCRPIX(int i) const { return wcs.wcstan.crpix[i]; }
+    double getCD(int i, int j) const { return wcs.wcstan.cd[i][j]; }
+
 private:
 
     bool hasWCS = false;


### PR DESCRIPTION
This change adds three lightweight getters to WCSData for reading the underlying WCS values: CRVAL, CRPIX, and CD. These accessors make it easier for callers to inspect WCS metadata without reaching into the internal structure directly, while keeping the existing data layout unchanged.