### PR TITLE
Fix internal solver cancellation hang in astrometry.net loops

### DIFF
--- a/stellarsolver/internalextractorsolver.cpp
+++ b/stellarsolver/internalextractorsolver.cpp
@@ -80,6 +80,7 @@ void InternalExtractorSolver::abort()
     quit();
 
     thejob.bp.cancelled = TRUE;
+    thejob.bp.solver.quit_now = TRUE;
     if(!isChildSolver)
         emit logOutput("Aborting...");
     m_WasAborted = true;


### PR DESCRIPTION
During solver aborts or timeouts, the background solver thread could block indefinitely inside astrometry.net's nested quad-matching loops. This is particularly prevalent on dense fields under unconstrained configurations (e.g. keepNum=0 or no scale hints), where a single newpoint search space is extremely large.

While the innermost math loops check 'solver->quit_now', they do not check the high-level 'bp->cancelled' flag. Setting 'bp->cancelled' only exits at the start of the outer newpoint loop, which was never reached while stuck in deep combinatorial recursion.

By setting 'thejob.bp.solver.quit_now = TRUE' in
'InternalExtractorSolver::abort()', we ensure all nested matching loops return immediately, stopping CPU usage and allowing the thread destructor to clean up and exit without hanging.